### PR TITLE
Update code with new nnSVG implementation to calculate LR statistics correctly

### DIFF
--- a/R/example_use_weights.Rmd
+++ b/R/example_use_weights.Rmd
@@ -28,7 +28,7 @@ w <- readRDS(file = "mean_var_project/DLPFC_151507_BRISC_estimation_spline.rds")
 #ix <- seq_len(ncol(y))
 ix <- c(1,2,3)
 out_brisc <- bplapply(ix, function(i) {
-
+  
   y_i = y[ ,i]
   X = data.frame(intercept = rep(1, n))
   #intercept only model
@@ -70,30 +70,40 @@ set.seed(123)
 no_weight_output <- nnSVG(spe_151507[c(1:10),])
 
 #multiply by weights after log transf.
-#w <- readRDS(file = "mean_var_project/DLPFC_151507_BRISC_estimation_spline.rds")
-w <- matrix(1, dim(spe_151507)[2], dim(spe_151507)[1])
-#w <- matrix(abs(rnorm(4221*1695, mean = 1, sd = 20)) , nrow = 4221)
+w <- readRDS(file = "mean_var_project/DLPFC_151507_BRISC_estimation_spline.rds")
+# w <- readRDS(file = "~/Desktop/weights.rds") # For Boyi only # TODO (boyiguo1): delete later
+# w <- matrix(1, dim(spe_151507)[2], dim(spe_151507)[1])
+# w <- matrix(abs(rnorm(4221*1695, mean = 1, sd = 20)) , nrow = 4221)
 
 weighted_counts <- t(w)*logcounts(spe_151507)
 assays(spe_151507) <- assays(spe_151507)[1]
-assay(spe_151507, "logcounts") <- weighted_counts # assign a new entry to assays slot, nnSVG will use "logcounts"
+assay(spe_151507, "weighted_logcounts") <- weighted_counts # assign a new entry to assays slot, nnSVG will use "logcounts"
+
+# Make sure nnSVG fixed the interceptless model 
+stopifnot(
+  "Please update your nnSVG to minimumly v1.5.3 to have the correct result" = 
+    packageVersion("nnSVG")>='1.5.3'
+)
 
 # set seed for reproducibility
 #run nnSVG with covariate
 LR_list <- c()
 for (i in c(1:10)) {
+  # browser()
   set.seed(123)
-  weight_output_i <- nnSVG(spe_151507[i,], X=matrix(w[,i]))
+  weight_output_i <- nnSVG(spe_151507[i,], X=matrix(w[,i]), assay_name = "weighted_logcounts")
   
-  y_i <- matrix(logcounts(spe_151507[1,]))
-  x <- matrix(w[,i])
+  # Do not need these code because nnSVG corrected this implementation
+  # TODO(): Detelete this
+  # y_i <- matrix(logcounts(spe_151507[1,]))
+  # x <- matrix(w[,i])
+  # 
+  # loglik_lm <- as.numeric(logLik(lm(y_i ~ x-1)))
+  # 
+  # LR_stat <- -2 * (loglik_lm - rowData(weight_output_i)$loglik)
+  # 
+  # pval <- 1 - pchisq(LR_stat, df = 2)
   
-  loglik_lm <- as.numeric(logLik(lm(y_i ~ x-1)))
-  
-  LR_stat <- -2 * (loglik_lm - rowData(weight_output_i)$loglik)
-  
-  pval <- 1 - pchisq(LR_stat, df = 2)
-
   LR_list <- append(LR_list, rowData(weight_output_i)$LR_stat)
 }
 

--- a/example_use_weights_breast.Rmd
+++ b/example_use_weights_breast.Rmd
@@ -39,24 +39,21 @@ w <- readRDS(file = "mean_var_project/breast_BRISC_estimation_spline.rds")
 
 weighted_counts <- t(w)*logcounts(spe_breast)
 assays(spe_breast) <- assays(spe_breast)[1]
-assay(spe_breast, "logcounts") <- weighted_counts # assign a new entry to assays slot, nnSVG will use "logcounts"
+assay(spe_breast, "weighted_logcounts") <- weighted_counts # assign a new entry to assays slot, nnSVG will use "logcounts"
+
+# Make sure nnSVG fixed the interceptless model 
+stopifnot(
+  "Please update your nnSVG to minimumly v1.5.3 to have the correct result" = 
+    packageVersion("nnSVG")>='1.5.3'
+)
 
 # set seed for reproducibility
 #run nnSVG with covariate
 LR_list <- c()
 for (i in c(1:10)) {
   set.seed(123)
-  weight_output_i <- nnSVG(spe_breast[i,], X=matrix(w[,i]))
-  
-  y_i <- matrix(logcounts(spe_breast[1,]))
-  x <- matrix(w[,i])
-  
-  loglik_lm <- as.numeric(logLik(lm(y_i ~ x-1)))
-  
-  LR_stat <- -2 * (loglik_lm - rowData(weight_output_i)$loglik)
-  
-  pval <- 1 - pchisq(LR_stat, df = 2)
-
+  weight_output_i <- nnSVG(spe_breast[i,], X=matrix(w[,i]), 
+                           assay_name = "weighted_logcounts")
   LR_list <- append(LR_list, rowData(weight_output_i)$LR_stat)
 }
 


### PR DESCRIPTION
Major Changes:
* Set up version confirmation to make sure using the updated nnSVG (you may need to re-install if you are running into an error with this line)
* Have weighted log counts as a new channel in spe `assay` such that would have a problem when re-running with clean up the session.
* Replace pseudocode with the updated nnSVG implementation to correctly calculate the LR statistics.